### PR TITLE
Broader platform support

### DIFF
--- a/attributes/atomic-testing.rb
+++ b/attributes/atomic-testing.rb
@@ -6,10 +6,10 @@ default['yum']['atomic-testing']['managed'] = false
 
 case node['platform']
 when 'fedora'
-  default['yum']['atomic-testing']['mirrorlist'] = 'http://updates.atomicorp.com/channels/mirrorlist/atomic-testing/fedora-$releasever-$basearch'
+  default['yum']['atomic-testing']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic-testing/fedora-$releasever-$basearch'
   default['yum']['atomic-testing']['description'] = 'Fedora Core $releasever - atomicrocketturtle.com - (Testing)'
 when 'redhat', 'centos', 'scientific'
-  default['yum']['atomic-testing']['mirrorlist'] = 'http://updates.atomicorp.com/channels/mirrorlist/atomic-testing/centos-$releasever-$basearch'
+  default['yum']['atomic-testing']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic-testing/centos-$releasever-$basearch'
   default['yum']['atomic-testing']['description'] = 'CentOS / Red Hat Enterprise Linux $releasever - atomicrocketturtle.com - (Testing)'
 else
   fail "Unsupported platform #{node['platform']}. Please review the cookbook requirements."

--- a/attributes/atomic-testing.rb
+++ b/attributes/atomic-testing.rb
@@ -11,6 +11,4 @@ when 'fedora'
 when 'redhat', 'centos', 'scientific'
   default['yum']['atomic-testing']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic-testing/centos-$releasever-$basearch'
   default['yum']['atomic-testing']['description'] = 'CentOS / Red Hat Enterprise Linux $releasever - atomicrocketturtle.com - (Testing)'
-else
-  fail "Unsupported platform #{node['platform']}. Please review the cookbook requirements."
 end

--- a/attributes/atomic.rb
+++ b/attributes/atomic.rb
@@ -11,6 +11,4 @@ when 'fedora'
 when 'redhat', 'centos', 'scientific'
   default['yum']['atomic']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic/centos-$releasever-$basearch'
   default['yum']['atomic']['description'] = 'CentOS / Red Hat Enterprise Linux $releasever - atomicrocketturtle.com'
-else
-  fail "Unsupported platform #{node['platform']}. Please review the cookbook requirements."
 end

--- a/attributes/atomic.rb
+++ b/attributes/atomic.rb
@@ -6,10 +6,10 @@ default['yum']['atomic']['managed'] = true
 
 case node['platform']
 when 'fedora'
-  default['yum']['atomic']['mirrorlist'] = 'http://updates.atomicorp.com/channels/mirrorlist/atomic/fedora-$releasever-$basearch'
+  default['yum']['atomic']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic/fedora-$releasever-$basearch'
   default['yum']['atomic']['description'] = 'Fedora Core $releasever - atomicrocketturtle.com'
 when 'redhat', 'centos', 'scientific'
-  default['yum']['atomic']['mirrorlist'] = 'http://updates.atomicorp.com/channels/mirrorlist/atomic/centos-$releasever-$basearch'
+  default['yum']['atomic']['mirrorlist'] = 'https://updates.atomicorp.com/channels/mirrorlist/atomic/centos-$releasever-$basearch'
   default['yum']['atomic']['description'] = 'CentOS / Red Hat Enterprise Linux $releasever - atomicrocketturtle.com'
 else
   fail "Unsupported platform #{node['platform']}. Please review the cookbook requirements."

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,10 +17,14 @@
 # limitations under the License.
 #
 
-include_recipe 'yum-epel' unless node['platform'] == 'fedora'
+include_recipe 'yum-epel' if platform_family?('rhel')
 
 %w(atomic atomic-testing).each do |repo|
   if node['yum'][repo]['managed']
+    if node['yum'][repo]['baseurl'].nil? && node['yum'][repo]['mirrorlist'].nil?
+      fail "The node['yum']['#{repo}'] baseurl and mirrorlist attributes are blank. The #{node['platform']} platform is probably unsupported by yum-atomic."
+    end
+
     yum_repository repo do
       baseurl node['yum'][repo]['baseurl']
       cost node['yum'][repo]['cost']


### PR DESCRIPTION
A couple of fixes that broaden the platform support a little. This initial change made a bit more sense when I intended to add openSUSE but then I remembered that SUSE doesn't use yum, despite being RPM-based. This still improves the situation for Amazon and Oracle Linux though.
