### PR TITLE
Depend on compat_resource instead of yum cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,8 +7,8 @@ provisioner:
 
 platforms:
   - name: centos-5.11
-  - name: centos-6.7
-  - name: centos-7.1
+  - name: centos-6.8
+  - name: centos-7.3
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ repositories.
 
 Requirements
 ------------
-* Chef 11 or higher
-* Depends on yum cookbook version 3.2 or higher and yum-epel
+* Chef 12.1 or higher
+* Depends on yum-epel
 
 Platform Support
 ----------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email 'brian.hays@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures yum-atomic repo'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.1.2'
+version '0.2.0'
 
 supports 'centos'
 supports 'redhat'
 supports 'scientific'
 supports 'fedora'
 
-depends 'yum', '~> 3.2'
+depends 'compat_resource', '>= 12.14.6'
 depends 'yum-epel'

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -11,8 +11,8 @@ describe 'yum-atomic::default' do
         :platform => 'centos',
         :version => '6.6'
       ) do |node|
-        node.set['yum']['atomic']['managed'] = true
-        node.set['yum']['atomic-testing']['managed'] = true
+        node.normal['yum']['atomic']['managed'] = true
+        node.normal['yum']['atomic-testing']['managed'] = true
       end.converge(described_recipe)
     end
 


### PR DESCRIPTION
This will require Chef 12.1 or higher. I would have left the version bump to you but Berkshelf has a really annoying bug where it will use dependencies from the supermarket on top of what is listed in the metadata unless you bump the version.